### PR TITLE
CI: run Miri

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,3 +67,19 @@ jobs:
       - name: Check whether it compiles
         run: |
           cargo check --all-features --verbose
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Git repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: miri
+      - name: Run Miri
+        run: |
+          cargo miri test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,12 +672,8 @@ mod test {
         let mut v = vec![1, 2, 3, 4, 5, 6];
 
         // Assuming we have a slice of pointers with a known length:
-        let ptrs = [
-            v[0..2].as_mut_ptr(),
-            v[2..4].as_mut_ptr(),
-            v[4..6].as_mut_ptr(),
-        ];
         let length = 2;
+        let ptrs: Vec<*mut _> = v.chunks_exact_mut(length).map(|s| s.as_mut_ptr()).collect();
 
         let sos = reusable_slice.from_iter_mut(
             ptrs.iter()


### PR DESCRIPTION
And Miri immediately found undefined behavior, luckily only in a test.

I was using non-mut sub-slices into the same container and then casting them to mutable pointers. Even though the sub-slices are non-overlapping, Miri counts this as UB.

Splitting the container into mutable slices before casting them to pointers seems to solve the problem.